### PR TITLE
feat: add PostHog analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ cast invoke my-agent "What files are in the current directory?"
 ### Guides
 - [Templates](https://docs.castari.com/guides/templates)
 - [Custom Agents](https://docs.castari.com/guides/custom-agents)
+- [Claude Code Plugin](https://docs.castari.com/guides/claude-code)
 - [MCP Integration](https://docs.castari.com/guides/mcp)
 - [Debugging](https://docs.castari.com/guides/debugging)
 - [Best Practices](https://docs.castari.com/guides/best-practices)

--- a/docs.json
+++ b/docs.json
@@ -139,6 +139,12 @@
       "linkedin": "https://linkedin.com/company/castari"
     }
   },
+  "analytics": {
+    "posthog": {
+      "apiKey": "phc_dTz46lezSNWVFetq8Z2EMWOnC5MMK6FTedUihHxrQ5s",
+      "apiHost": "https://us.i.posthog.com"
+    }
+  },
   "feedback": {
     "thumbsRating": true,
     "suggestEdit": true

--- a/docs.json
+++ b/docs.json
@@ -95,6 +95,7 @@
             "pages": [
               "guides/templates",
               "guides/custom-agents",
+              "guides/claude-code",
               "guides/mcp",
               "guides/debugging",
               "guides/best-practices",

--- a/docs.json
+++ b/docs.json
@@ -17,6 +17,10 @@
       "url": "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
     }
   },
+  "banner": {
+    "content": "**New:** Deploy agents directly from Claude Code with `/castari-deploy`. [Learn more](/guides/claude-code)",
+    "dismissible": true
+  },
   "favicon": "/favicon.svg",
   "logo": {
     "light": "/logo/light.svg",
@@ -24,6 +28,10 @@
   },
   "navbar": {
     "links": [
+      {
+        "label": "Claude Code Plugin",
+        "href": "/guides/claude-code"
+      },
       {
         "label": "Dashboard",
         "href": "https://app.castari.com"

--- a/guides/claude-code.mdx
+++ b/guides/claude-code.mdx
@@ -1,0 +1,88 @@
+---
+title: "Claude Code Plugin"
+description: "Deploy agents to Castari directly from Claude Code"
+---
+
+# Claude Code Plugin
+
+The Castari plugin for [Claude Code](https://claude.ai/code) lets you deploy agents without leaving your editor. Type `/castari-deploy` and the skill handles CLI installation, authentication, project scaffolding, and deployment — all in one flow.
+
+<Info>
+**View on skills.sh:** [skills.sh/castari/cli](https://skills.sh/castari/cli)
+</Info>
+
+## Install the Plugin
+
+```bash
+npx skills add castari/cli
+```
+
+This installs the Castari plugin into your Claude Code environment. Once installed, the `/castari-deploy` skill is available in any project.
+
+## Using `/castari-deploy`
+
+Type `/castari-deploy` in Claude Code (or ask Claude to "deploy to Castari") and the skill walks through the full deployment flow:
+
+### Step 1: CLI Check
+
+The skill checks if the Castari CLI is installed by running `cast --version`. If not found, it installs the CLI globally via npm.
+
+### Step 2: Authentication
+
+Runs `cast whoami` to check if you're logged in. If not, it triggers `cast login` which opens your browser for Clerk OAuth authentication.
+
+### Step 3: Project Configuration
+
+Looks for `castari.json` in your project root. If one exists, the skill confirms its configuration with you. If not, it:
+
+- Detects your entrypoint file (e.g., `src/index.ts`, `index.js`)
+- Asks you for an agent name
+- Generates a `castari.json` manifest
+
+### Step 4: Deploy
+
+Runs `cast deploy` to package your project and deploy it to an isolated cloud sandbox.
+
+### Step 5: Verification
+
+Shows you a summary of the deployment — agent name, status, and sandbox ID.
+
+### Step 6: Testing
+
+Offers to test the deployed agent by running `cast invoke` with a prompt you provide.
+
+## Trigger Phrases
+
+The skill activates when you ask Claude to:
+
+- "deploy to Castari"
+- "deploy my agent"
+- "castari deploy"
+- "push agent to Castari"
+- "ship my agent"
+- "set up Castari"
+
+Or any variation of deploying an agent to Castari.
+
+## Requirements
+
+- [Node.js](https://nodejs.org) 18 or higher
+- A [Castari account](https://app.castari.com) (free to sign up)
+- [Claude Code](https://claude.ai/code) installed
+
+## See Also
+
+<CardGroup cols={2}>
+  <Card title="Quick Start" icon="rocket" href="/quickstart">
+    Manual deployment walkthrough
+  </Card>
+  <Card title="CLI Reference" icon="terminal" href="/cli/overview">
+    Full CLI command reference
+  </Card>
+  <Card title="Custom Agents" icon="pen" href="/guides/custom-agents">
+    Building agents from scratch
+  </Card>
+  <Card title="Templates" icon="grid" href="/guides/templates">
+    Start from a template
+  </Card>
+</CardGroup>

--- a/index.mdx
+++ b/index.mdx
@@ -27,6 +27,10 @@ Castari is the natural runtime for AI agents. We deploy your Claude agents in se
   </Card>
 </CardGroup>
 
+<Tip>
+**Using Claude Code?** Type `/castari-deploy` and deploy your agent without leaving the editor. Install the plugin with `npx skills add castari/cli`. [Get started →](/guides/claude-code)
+</Tip>
+
 ## How It Works
 
 ```bash

--- a/installation.mdx
+++ b/installation.mdx
@@ -33,6 +33,10 @@ Install the Castari CLI to deploy and manage agents from your terminal.
 cast --version
 ```
 
+<Tip>
+**Using Claude Code?** Install the [Castari plugin](https://skills.sh/castari/cli) with `npx skills add castari/cli` and type `/castari-deploy` to handle installation, auth, and deployment in one step. [Learn more](/guides/claude-code).
+</Tip>
+
 You should see output like:
 
 ```

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -11,6 +11,10 @@ Deploy your first Claude agent in under 5 minutes.
 **Prerequisites:** Node.js 18+ and npm installed.
 </Info>
 
+<Tip>
+**Using Claude Code?** Type `/castari-deploy` and the skill handles all of these steps for you. Install it with `npx skills add castari/cli`. [Learn more](/guides/claude-code).
+</Tip>
+
 <Steps>
 
 <Step title="Install the CLI">


### PR DESCRIPTION
## Summary
- Add PostHog analytics via Mintlify's native `analytics.posthog` config

## Test plan
- [ ] Verify PostHog events appear in the PostHog dashboard after visiting docs pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/castari/docs/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
